### PR TITLE
ADD : 메인 페이지 - 제품 리스트 구현 완료

### DIFF
--- a/public/data/ProductContent.json
+++ b/public/data/ProductContent.json
@@ -1,0 +1,56 @@
+[
+  {
+    "id": 0,
+    "imgUrl": "https://wiselystatic.s3.amazonaws.com/THUMBNAIL/prod/assets/images/item/200201000/main/ow-booster-porecontrol-main.png",
+    "desc": "탄력/잡티/모공 세럼80mL",
+    "price": "5,900원"
+  },
+  {
+    "id": 1,
+    "imgUrl": "https://wiselystatic.s3.amazonaws.com/THUMBNAIL/prod/assets/images/item/700101000/main/rz-sanitarypad-largemedium-main.png",
+    "desc": "유기농 순면 생리대 중형/대형",
+    "price": "2,300원"
+  },
+  {
+    "id": 2,
+    "imgUrl": "https://wiselystatic.s3.amazonaws.com/THUMBNAIL/prod/assets/images/item/400102000/main/hb-vitamin-main.png",
+    "desc": "활력충전 멀티비타민",
+    "price": "5,800원"
+  },
+  {
+    "id": 3,
+    "imgUrl": "https://wiselystatic.s3.amazonaws.com/THUMBNAIL/prod/assets/images/item/300101000/main/hw-shampoo-hairloss-main.png",
+    "desc": "탈모 케어 샴푸",
+    "price": "5,900원"
+  },
+  {
+    "id": 4,
+    "imgUrl": "https://wiselystatic.s3.amazonaws.com/THUMBNAIL/prod/assets/images/item/101050000/main/ws-startset-navy-pro-main.png",
+    "desc": "면도기 스타터세트",
+    "price": "4,900원"
+  },
+  {
+    "id": 5,
+    "imgUrl": "https://wiselystatic.s3.amazonaws.com/THUMBNAIL/prod/assets/images/item/500201000/main/pl-toothpaste-main.png",
+    "desc": "자연유래 성분 치약",
+    "price": "1,900원"
+  },
+  {
+    "id": 6,
+    "imgUrl": "https://wiselystatic.s3.amazonaws.com/THUMBNAIL/prod/assets/images/item/700101000/main/rz-sanitarypad-largemedium-main.png",
+    "desc": "유기농 순면 생리대 중형/대형",
+    "price": "2,300원"
+  },
+  {
+    "id": 7,
+    "imgUrl": "https://wiselystatic.s3.amazonaws.com/THUMBNAIL/prod/assets/images/item/400102000/main/hb-vitamin-main.png",
+    "desc": "활력충전 멀티비타민",
+    "price": "5,800원"
+  },
+  {
+    "id": 8,
+    "imgUrl": "https://wiselystatic.s3.amazonaws.com/THUMBNAIL/prod/assets/images/item/300101000/main/hw-shampoo-hairloss-main.png",
+    "desc": "탈모 케어 샴푸",
+    "price": "5,900원"
+  }
+]

--- a/src/pages/Main/Main.js
+++ b/src/pages/Main/Main.js
@@ -1,5 +1,17 @@
+import './Main.scss';
+import ProductContent from './ProductContent/ProductContent';
+
 function Main() {
-  return <h1>Main입니다.</h1>;
+  return (
+    <div className="Main">
+      <h1>Header</h1>
+      <div>Carousel</div>
+      <div>
+        <h1>카테고리</h1>
+      </div>
+      <ProductContent />
+    </div>
+  );
 }
 
 export default Main;

--- a/src/pages/Main/ProductContent/Product/Product.js
+++ b/src/pages/Main/ProductContent/Product/Product.js
@@ -1,0 +1,15 @@
+import './product.scss';
+
+const Product = ({ imgUrl, desc, price }) => {
+  return (
+    <li className="productRigth">
+      <div className="product">
+        <img className="productImg" src={imgUrl} alt="" />
+        <p className="productInfo">{desc}</p>
+        <h2 className="productTitle">{price}</h2>
+      </div>
+    </li>
+  );
+};
+
+export default Product;

--- a/src/pages/Main/ProductContent/Product/product.scss
+++ b/src/pages/Main/ProductContent/Product/product.scss
@@ -1,0 +1,25 @@
+.productRigth {
+  margin-right: 21px;
+
+  .product {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    .productImg {
+      width: 250px;
+      height: 250px;
+    }
+
+    .productInfo {
+      margin-top: 24px;
+      font-size: 18px;
+      line-height: 28px;
+      color: #838383;
+    }
+
+    .productTitle {
+      font-size: 20px;
+      line-height: 30px;
+    }
+  }
+}

--- a/src/pages/Main/ProductContent/ProductContent.js
+++ b/src/pages/Main/ProductContent/ProductContent.js
@@ -1,0 +1,69 @@
+import { useEffect, useRef, useState } from 'react';
+import './ProductContent.scss';
+
+import Product from './Product/Product';
+import ProductButton from './productButton/ProductButton';
+
+const ProductContent = () => {
+  const [productData, setProductData] = useState([]);
+  const [productPos, setProductPos] = useState(0);
+
+  const container_Carousel = useRef();
+  useEffect(() => {
+    container_Carousel.current.style.transform = `translateX(${productPos}px)`;
+  }, [productPos]);
+
+  useEffect(() => {
+    const checkStatus = res => {
+      if (!res.ok) throw new Error(`Again Check Status: ${res.status}`);
+      return res.json();
+    };
+    const uploadProductData = data => {
+      setProductData([...data]);
+    };
+    const getProductData = url =>
+      fetch(url, {
+        method: 'GET',
+      });
+
+    getProductData('/data/ProductContent.json')
+      .then(checkStatus)
+      .then(uploadProductData)
+      .catch(error => console.error(error));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const movePrev = () => {
+    setProductPos(prop => prop + 271);
+  };
+
+  const moveNext = () => {
+    setProductPos(prop => prop - 271);
+  };
+
+  return (
+    <main className="ProductContent">
+      <section className="content">
+        <h1 className="contentTitle">와이즐리 베스트 TOP6</h1>
+        <p className="contentInfo">지난 달 가장 많은 판매량을 기록했어요</p>
+        <ul className="productList" ref={container_Carousel}>
+          {productData.map(data => (
+            <Product key={data.id} {...data} />
+          ))}
+        </ul>
+        {productPos === 0 ? (
+          <ProductButton btnType="next" handleSlide={moveNext} />
+        ) : productPos >= -1084 ? (
+          <>
+            <ProductButton btnType="prev" handleSlide={movePrev} />
+            <ProductButton btnType="next" handleSlide={moveNext} />
+          </>
+        ) : (
+          <ProductButton btnType="prev" handleSlide={movePrev} />
+        )}
+      </section>
+    </main>
+  );
+};
+
+export default ProductContent;

--- a/src/pages/Main/ProductContent/ProductContent.scss
+++ b/src/pages/Main/ProductContent/ProductContent.scss
@@ -1,0 +1,27 @@
+.ProductContent {
+  max-width: 1140px;
+  margin: 0 auto;
+  overflow-x: hidden;
+  overflow-y: hidden;
+
+  .content {
+    margin-bottom: 150px;
+    position: relative;
+
+    .contentTitle {
+      font-size: 38px;
+      line-height: 50px;
+    }
+
+    .contentInfo {
+      font-size: 20px;
+      line-height: 30px;
+      color: #838383;
+    }
+
+    .productList {
+      display: flex;
+      margin-top: 54px;
+    }
+  }
+}

--- a/src/pages/Main/ProductContent/productButton/ProductButton.js
+++ b/src/pages/Main/ProductContent/productButton/ProductButton.js
@@ -1,0 +1,7 @@
+import './ProductButton.scss';
+
+const ProductButton = ({ btnType, handleSlide }) => {
+  return <div className={`button ${btnType}`} onClick={handleSlide} />;
+};
+
+export default ProductButton;

--- a/src/pages/Main/ProductContent/productButton/ProductButton.scss
+++ b/src/pages/Main/ProductContent/productButton/ProductButton.scss
@@ -1,0 +1,31 @@
+.button {
+  position: absolute;
+  top: 65%;
+  width: 3rem;
+  height: 3rem;
+  background-color: rgba(255, 255, 255, 0.5);
+  transform: translateY(-50%);
+  border-radius: 50%;
+  cursor: pointer;
+  z-index: 100;
+
+  &:after {
+    content: '';
+    position: absolute;
+    width: 10px;
+    height: 10px;
+    top: 50%;
+    left: 54%;
+    border-right: 2px solid rgba(0, 0, 0, 0.5);
+    border-bottom: 2px solid rgba(0, 0, 0, 0.5);
+    transform: translate(-50%, -50%) rotate(135deg);
+  }
+}
+.next {
+  right: 9%;
+
+  &:after {
+    left: 47%;
+    transform: translate(-50%, -50%) rotate(-45deg);
+  }
+}


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [X] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표
- 제품 리스트를 슬라이드 형식으로 만들기
- 단. 제품이 끝까지 보이면 다음 제품으로 넘어가지 않게 만들기
<br />

## :: 구현 사항 설명
- 제품을 받아온 다음에 한 컨테이너에 제품들을 펼쳐놓는다. 
- 제한된 크기 밖에서는 hidden을 줘서 안보이게 한다.
- 컨테이너를 선택한 다음에 translateX를 이용해서 제품의 크기만큼 (+, -) 할 수 있게 설정한다.
- prev 버튼은 +, next 버튼은 -
- 선택한 버튼에 따라서 제품을 감싼 컨테이너를 움직인다.

<br />

## :: 성장 포인트 
- 처음에는 전에 만들었던 캐러셀에서 코드를 가져오기만 하면 될 줄알았는데
- 가져와보니 둘이 완전히 다른 성향이었던 것을 알게 되었다.
- 이러한 과정을 통해 아무 생각없이 전에 작성했던 코드를 함부로 가져오면 안되는 것을 알게 되었다.
- html, css 작성하는 방법이 조금씩 생각나고 있다.
<br />
